### PR TITLE
Don't store celery task results

### DIFF
--- a/cts/settings/base.py
+++ b/cts/settings/base.py
@@ -284,6 +284,7 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=60),
     },
 }
+CELERY_RESULT_BACKEND = None  # We never care about task results
 
 # See https://github.com/johnsensible/django-sendfile
 SENDFILE_URL = "/protected/"

--- a/ona/tasks.py
+++ b/ona/tasks.py
@@ -15,7 +15,7 @@ from ona.representation import PackageScanFormSubmission, OnaItemBase
 logger = logging.getLogger(__name__)
 
 
-@app.task
+@app.task(ignore_result=True)
 def process_new_package_scans():
     """Updates the local database with new package tracking form submissions"""
     logger.debug("process_new_package_scans task starting...")
@@ -64,7 +64,7 @@ def process_new_package_scans():
     logger.debug("process_new_package_scans task done")
 
 
-@app.task
+@app.task(ignore_result=True)
 def verify_deviceid():
     """Store the DeviceID and QR code"""
     last_retrieval = None


### PR DESCRIPTION
I think Celery was storing the "result" of every task we ran. We schedule them to run 5 times an hour (one is 4x/hour, one is 1x/hour) so that adds up to a lot of results that we're never looking at, and I think that might be what's clogging up rabbitmq and making it take so long to start when it gets shut down abruptly.
