### PR TITLE
More tweaks to fetching Ona form submissions

### DIFF
--- a/ona/api.py
+++ b/ona/api.py
@@ -56,6 +56,10 @@ class OnaApiClient(object):
             raise OnaApiClientException(0, "SSL error, see log (%s)" % e, url=url)
         if "404 Not Found" in response.text:
             raise Http404
+        if not len(response.content):
+            # An empty response is not valid JSON and probably indicates something wrong
+            # at the server. Raise a more specific error than just "couldn't parse JSON".
+            raise OnaApiClientException(0, "ONA response was empty", url=url)
         try:
             data = response.json()
         except Exception as e:

--- a/ona/tests/test_api.py
+++ b/ona/tests/test_api.py
@@ -19,6 +19,7 @@ class TestClientRequest(TestCase):
         # Create a mock response that raises an exception when we try to get the json from it
         mock_response = MagicMock()
         mock_response.text = "This was the content"
+        mock_response.content = mock_response.text.encode('utf-8')
         mock_response.json.side_effect = Exception("This is an exception")
 
         # Mock session that returns our mock response on a 'get' call.
@@ -38,5 +39,29 @@ class TestClientRequest(TestCase):
                 self.assertIn('could not be parsed', s)
                 self.assertIn("This is an exception", s)
                 self.assertIn("This was the content", s)
+            else:
+                self.fail("Expected OnaApiClientException")
+
+    def test_empty_response(self):
+        mock_response = MagicMock()
+        mock_response.text = ""
+        mock_response.content = mock_response.text.encode('utf-8')
+
+        # Mock session that returns our mock response on a 'get' call.
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+
+        client = OnaApiClient('example.com', '2384729347234')
+        with patch.object(client, 'session') as mock_session_method:
+            # 'session' method on our client returns our mock session
+            mock_session_method.return_value = mock_session
+
+            try:
+                client.get('foo')
+            except OnaApiClientException as e:
+                # Make sure the exception has lots of useful info
+                s = str(e)
+                self.assertIn('empty', s)
+                self.assertIn('foo', s)
             else:
                 self.fail("Expected OnaApiClientException")

--- a/ona/tests/test_tasks.py
+++ b/ona/tests/test_tasks.py
@@ -13,7 +13,8 @@ from ona.representation import OnaItemBase
 from shipments.models import PackageScan, Shipment
 from shipments.tests.factories import PackageFactory
 from ona.models import FormSubmission, minimum_aware_datetime
-from ona.tasks import process_new_package_scans, verify_deviceid, reset_bad_form_ids, bad_form_ids
+from ona.tasks import process_new_package_scans, verify_deviceid, reset_bad_form_ids, bad_form_ids, \
+    forget_form_definitions
 from ona.tests.test_models import PACKAGE_DATA, USER_CODE_DATA, QR_CODE
 
 
@@ -28,6 +29,7 @@ from ona.tests.test_models import PACKAGE_DATA, USER_CODE_DATA, QR_CODE
 class ProcessNewPackageScansTestCase(TestCase):
     def setUp(self):
         reset_bad_form_ids()
+        forget_form_definitions()
 
     def test_update_package_locations(self, mock_ona_form_def, mock_ona_form_submissions):
         self.assertFalse(FormSubmission.objects.all())
@@ -86,6 +88,7 @@ class DeviceIdToUserTestCase(TestCase):
     def setUp(self):
         self.user = CtsUserFactory(code=QR_CODE)
         reset_bad_form_ids()
+        forget_form_definitions()
 
     def test_verify_deviceid(self, mock_ona_form_submissions, mock_get_form_definition):
         self.assertEqual('', self.user.deviceid)


### PR DESCRIPTION
- A more specific error message when a response is empty.
- Don't fetch the same form's definition repeatedly.
