### PR TITLE
Speed up maps

### DIFF
--- a/shipments/migrations/0022_add_scan_shipment.py
+++ b/shipments/migrations/0022_add_scan_shipment.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shipments', '0021_set_country_in_scans'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='packagedbview',
+            options={'managed': False, 'verbose_name': 'package'},
+        ),
+        migrations.AlterModelOptions(
+            name='shipmentdbview',
+            options={'managed': False, 'verbose_name': 'shipment'},
+        ),
+        migrations.AlterField(
+            model_name='shipment',
+            name='status',
+            field=models.IntegerField(default=1, db_index=True, choices=[(1, b'In progress'), (2, b'Ready for pickup'), (3, b'Picked up'), (4, b'In transit'), (5, b'Received'), (6, b'Overdue'), (7, b'Lost'), (8, b'Canceled')]),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='packagescan',
+            name='shipment',
+            field=models.ForeignKey(related_name='scans', to='shipments.Shipment', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/shipments/migrations/0023_set_scan_shipment.py
+++ b/shipments/migrations/0023_set_scan_shipment.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def no_op(apps, schema_editor):
+    pass
+
+
+
+def set_scan_shipment(apps, schema_editor):
+    PackageScan = apps.get_model('shipments', 'PackageScan')
+    Shipment = apps.get_model('shipments', 'Shipment')
+
+    for shipment in Shipment.objects.all():
+        PackageScan.objects.filter(shipment=None, package__shipment=shipment).update(shipment=shipment)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shipments', '0022_add_scan_shipment'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_scan_shipment, no_op),
+    ]

--- a/shipments/migrations/0024_recreate_views.py
+++ b/shipments/migrations/0024_recreate_views.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+from  ..db_views import add_views, drop_views
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shipments', '0023_set_scan_shipment'),
+    ]
+
+    operations = [
+        # Forward or back, we drop the views and then add them again
+        migrations.RunPython(drop_views, add_views),
+        migrations.RunPython(add_views, drop_views),
+    ]

--- a/shipments/migrations/0025_auto_20150914_1603.py
+++ b/shipments/migrations/0025_auto_20150914_1603.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shipments', '0024_recreate_views'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='packagescan',
+            name='shipment',
+            field=models.ForeignKey(related_name='scans', to='shipments.Shipment'),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
As we move the database server off the web server system,
slow queries and unnecessary queries have a more noticeable
impact.

These changes speed up maps, at least in some cases, by
using select_related to pre-fetch related data, `only` to
avoid downloading unnecessary data, and not querying the
SQL View unless we need aggregate data.

Since most of these queries happen on Ajax calls, I ended
up temporarily running them on a regular GET so I could
look at the queries using django debug toolbar.

Even with these changes, maps filtering on donor are still
unacceptably slow, IMHO. That needs more investigation.
