### PR TITLE
Install django-extensions and allow env to set DB_USER and DB_NAME

### DIFF
--- a/cts/settings/base.py
+++ b/cts/settings/base.py
@@ -163,6 +163,7 @@ INSTALLED_APPS = (
     'django_tables2',
     'django_tables2_reports',
     'bootstrap3',
+    'django_extensions',
     # Project apps
     'catalog',
     'shipments',

--- a/cts/settings/staging.py
+++ b/cts/settings/staging.py
@@ -32,8 +32,8 @@ DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
 # If these lines change, change conf/salt/project/db/init_sls
-DATABASES['default']['NAME'] = 'cts_%s' % INSTANCE
-DATABASES['default']['USER'] = 'cts_%s' % INSTANCE
+DATABASES['default']['NAME'] = os.environ.get('DB_NAME', 'cts_%s' % INSTANCE)
+DATABASES['default']['USER'] = os.environ.get('DB_USER', 'cts_%s' % INSTANCE)
 
 DATABASES['default']['HOST'] = os.environ.get('DB_HOST', '')
 DATABASES['default']['PORT'] = os.environ.get('DB_PORT', '')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,4 +40,4 @@ PyYAML==3.11
 -e hg+https://bitbucket.org/scottm_caktus/django-dbbackup#egg=django-dbbackup
 
 # To use 'sqldsn'
-git+https://github.com/caktus/django-extensions.git@sqldsn_postgis#egg=django-extensions
+django-extensions==1.5.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,3 +38,6 @@ PyYAML==3.11
 
 # For backups
 -e hg+https://bitbucket.org/scottm_caktus/django-dbbackup#egg=django-dbbackup
+
+# To use 'sqldsn'
+git+https://github.com/caktus/django-extensions.git@sqldsn_postgis#egg=django-extensions


### PR DESCRIPTION
Changes to help with configuring the servers to use databases on RDS.

django-extensions provides a sqldsn management command that helps extract the exact settings the server is configured to use.
