### PR TITLE
Allow use of a new form for Vouchers

### DIFF
--- a/cts/settings/base.py
+++ b/cts/settings/base.py
@@ -276,8 +276,8 @@ WORLD_BORDERS_SHAPEFILE = os.path.join(
 
 
 CELERYBEAT_SCHEDULE = {
-    'process_new_package_scans': {
-        'task': 'ona.tasks.process_new_package_scans',
+    'process_new_scans': {
+        'task': 'ona.tasks.process_new_scans',
         'schedule': timedelta(minutes=15),
     },
     'verify_deviceid': {

--- a/cts/settings/staging.py
+++ b/cts/settings/staging.py
@@ -78,7 +78,7 @@ LOG_DIR = os.path.join(os.path.dirname(PROJECT_ROOT), 'log', INSTANCE)
 # ONA related settings
 ONA_DOMAIN = os.environ.get('ONA_DOMAIN%s' % INSTANCE_SUFFIX, 'ona.io')
 ONA_API_ACCESS_TOKEN = os.environ.get('ONA_API_ACCESS_TOKEN%s' % INSTANCE_SUFFIX, '')
-ONA_PACKAGE_FORM_IDS = os.environ.get('ONA_PACKAGE_FORM_IDS%s' % INSTANCE_SUFFIX, '11983').split(';')  # noqa
+ONA_FORM_IDS = os.environ.get('ONA_FORM_IDS%s' % INSTANCE_SUFFIX, '11983').split(';')  # noqa
 ONA_DEVICEID_VERIFICATION_FORM_ID = \
     os.environ.get('ONA_DEVICEID_VERIFICATION_FORM_ID%s' % INSTANCE_SUFFIX, '0')
 
@@ -88,7 +88,7 @@ SENDFILE_URL = "/protected/"
 SENDFILE_BACKEND = 'sendfile.backends.nginx'
 
 
-CELERYBEAT_SCHEDULE['process_new_package_scans']['schedule'] = timedelta(minutes=2)
+CELERYBEAT_SCHEDULE['process_new_scans']['schedule'] = timedelta(minutes=2)
 CELERYBEAT_SCHEDULE['verify_deviceid']['schedule'] = timedelta(minutes=2)
 
 LOGGING = {

--- a/docs/user/mobile_forms.rst
+++ b/docs/user/mobile_forms.rst
@@ -43,7 +43,7 @@ Upload Form Data
 ODK Collect stores completed form submissions on the device. ODK Collect can  be configured
 to automatically upload stored form submissions when the  device is conected to wifi.
 
-If automatic uploadi is not configured, you must manually upload the completed forms.
+If automatic upload is not configured, you must manually upload the completed forms.
 
 #. Select *Send Finalized Form*
 #. Select the form instance(s) to upload
@@ -81,3 +81,11 @@ than the User Device Capture Form:
 * **Shipment Inomplete Reason** -- Supply the reason the Shipment is incomplete
 
 
+Voucher Tracking Form
+----------------------
+
+The Voucher Tracking form allows IRC personnel to activate a voucher which is to be given to a
+recipient. This is similar to the Package Delivery Form in that it collects location information.
+Unlike a Package Delivery Form, each Voucher Tracking Form is meant to track only one package, which
+happens to be a single voucher. It also collects information about the beneficiary, approving party,
+voucher value, and issue/expiration dates.

--- a/ona/management/commands/update_package_locations.py
+++ b/ona/management/commands/update_package_locations.py
@@ -7,7 +7,7 @@ import logging
 
 from django.core.management.base import NoArgsCommand
 
-from ona.tasks import process_new_package_scans
+from ona.tasks import process_new_scans
 
 
 class Command(NoArgsCommand):
@@ -18,4 +18,4 @@ class Command(NoArgsCommand):
         logger.setLevel(logging.DEBUG)
         logger.addHandler(logging.StreamHandler())
 
-        process_new_package_scans()
+        process_new_scans()

--- a/ona/models.py
+++ b/ona/models.py
@@ -89,7 +89,7 @@ def record_package_location(sender, instance, **kwargs):
     # Only record package locations for package tracking forms
     try:
         logger.debug("record_package_location...")
-        form_ids = [int(x) for x in settings.ONA_PACKAGE_FORM_IDS]
+        form_ids = [int(x) for x in settings.ONA_FORM_IDS]
         if kwargs.get('created', False) and int(instance.data['form_id']) in form_ids:
             submission = PackageScanFormSubmission(instance.data)
             logger.debug("New formsubmission. %d QR codes", len(submission.get_qr_codes()))

--- a/ona/representation.py
+++ b/ona/representation.py
@@ -87,19 +87,12 @@ class PackageScanFormSubmission(OnaItemBase):
 
     def get_qr_codes(self):
         """Return a unique set of package or voucher qr codes"""
-        old_key = 'package'
-        new_key = 'package_information/package'
-        voucher_key = 'voucher_information/qr_code'
         if self.is_voucher():
-            return [getattr(self, voucher_key)]
-        elif hasattr(self, new_key):
-            key = '{0}/qr_code'.format(new_key)
-            return set([x[key] for x in json.loads(getattr(self, new_key)) if key in x])
-        elif hasattr(self, old_key):
-            key = '{0}/qr_code'.format(old_key)
-            return set([x[key] for x in json.loads(self.package) if key in x])
+            key = 'voucher_information/qr_code'
+            return [getattr(self, key)]
         else:
-            return []
+            key = 'package/qr_code'
+            return set([x[key] for x in json.loads(self.package) if key in x])
 
     def get_current_packagescan_label(self):
         """

--- a/ona/tasks.py
+++ b/ona/tasks.py
@@ -32,11 +32,11 @@ def forget_form_definitions():
 
 
 @app.task(ignore_result=True)
-def process_new_package_scans():
+def process_new_scans():
     """Updates the local database with new package tracking form submissions"""
-    logger.debug("process_new_package_scans task starting...")
+    logger.debug("process_new_scans task starting...")
     try:
-        form_ids = [int(x) for x in settings.ONA_PACKAGE_FORM_IDS]
+        form_ids = [int(x) for x in settings.ONA_FORM_IDS]
         for form_id in form_ids:
             if form_id in bad_form_ids:
                 return
@@ -52,7 +52,7 @@ def process_new_package_scans():
                 else:
                     # Logging an error should result in an email to the admins so they
                     # know to fix this.
-                    logger.error("Bad ONA_PACKAGE_FORM_ID: %s" % form_id)
+                    logger.error("Bad ONA_FORM_ID: %s" % form_id)
                     # Let's not keep trying for the bad form ID. We'll have to change the
                     # settings and restart to fix it.
                     bad_form_ids.add(form_id)
@@ -73,17 +73,17 @@ def process_new_package_scans():
                 submissions = client.get_form_submissions(form_id, since=since)
             except Http404:
                 logger.error(
-                    "Got 404 getting submissions for ONA_PACKAGE_FORM_ID = %s" % form_id)
+                    "Got 404 getting submissions for ONA_FORM_ID = %s" % form_id)
                 return
             except OnaApiClientException as e:
                 if e.status_code != 404:
                     raise
                 logger.error(
-                    "Got 404 getting submissions for ONA_PACKAGE_FORM_ID = %s" % form_id)
+                    "Got 404 getting submissions for ONA_FORM_ID = %s" % form_id)
                 return
 
             logger.debug(
-                "process_new_package_scans downloaded %d submitted forms" % len(submissions))
+                "process_new_scans downloaded %d submitted forms" % len(submissions))
             # add the form definition JSON to each submission
             for data in submissions:
                 data.update({'form_id': form_id})
@@ -109,8 +109,8 @@ def process_new_package_scans():
     except OnaApiClientException:
         logger.exception("Error communicating with Ona server")
     except Exception:
-        logger.exception("Something blew up in process_new_package_scans")
-    logger.debug("process_new_package_scans task done")
+        logger.exception("Something blew up in process_new_scans")
+    logger.debug("process_new_scans task done")
 
 
 @app.task(ignore_result=True)

--- a/ona/tests/test_models.py
+++ b/ona/tests/test_models.py
@@ -35,8 +35,8 @@ PACKAGE_DATA = """
     "_submitted_by": null,
     "formhub/uuid": "799705ba0bd54b4d97bcf43644e4c272",
     "_id": 150250,
-    "package_information/package": [
-        {"package_information/package/qr_code": "test", "package_information/package/position": "1"}
+    "package": [
+        {"package/qr_code": "test", "package/position": "1"}
     ],
     "_submission_time": "2014-07-25T17:19:15",
     "governate": "asdfasfd",
@@ -65,7 +65,6 @@ PACKAGE_DATA = """
 VOUCHER_DATA = """
 {
     "_notes": [],
-    "package_count": "1",
     "_xform_id_string": "123",
     "_bamboo_dataset_id": "",
     "_tags": [],
@@ -75,10 +74,8 @@ VOUCHER_DATA = """
     "district": "asdfasdf",
     "_geolocation": ["35.7201", "-79.1772"],
     "_status": "submitted_via_web",
-    "num_packages": "1",
     "today": "2014-07-25",
     "gps": "35.7201 -79.1772 0 24000",
-    "complete": "yes",
     "_uuid": "2a11435f-8eaf-44f9-bd75-00a4bac8fbcd",
     "_submitted_by": null,
     "formhub/uuid": "799705ba0bd54b4d97bcf43644e4c272",
@@ -89,7 +86,7 @@ VOUCHER_DATA = """
     "_attachments": [],
     "deviceid": "enketo.org:nlwPcZ7s4nDDhvk8",
     "sub_district": "asdfasdf",
-    "form_id": "123",
+    "form_id": "456",
     "form_definition": {
         "choices": {
             "location_list": [
@@ -138,7 +135,8 @@ USER_CODE_DATA = """
 """
 
 
-@override_settings(ONA_PACKAGE_FORM_IDS=[123, 456], ONA_DEVICEID_VERIFICATION_FORM_ID=111)
+@override_settings(ONA_FORM_IDS=[123, 456],
+                   ONA_DEVICEID_VERIFICATION_FORM_ID=111)
 class FormSubmissionTestCase(TestCase):
     def test_record_package_location(self):
         PackageFactory(code=QR_CODE)

--- a/ona/tests/test_representation.py
+++ b/ona/tests/test_representation.py
@@ -8,18 +8,13 @@ from ona.representation import OnaItemBase, PackageScanFormSubmission
 
 SUBMITTED_AT_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
-SUBMISSION_JSON = {
+VOUCHER_JSON = {
     'gps': '24.24 25.25 1.0 5.0',
     'voucher_information/qr_code': 'test',
     '_submission_time': datetime.now().strftime(SUBMITTED_AT_FORMAT),
 }
 
-NEW_PACKAGE_JSON = {
-    u'package_information/package':
-    u'[{"package_information/package/qr_code": "test", "package_information/package/position": "1"}]'  # noqa
-}
-
-OLD_PACKAGE_JSON = {
+PACKAGE_JSON = {
     u'package':
     u'[{"package/qr_code": "test", "package/position": "1"}]'
 }
@@ -61,53 +56,49 @@ class ProductTestCase(unittest.TestCase):
     """Basic test for Product object."""
 
     def setUp(self):
-        self.form_submission = PackageScanFormSubmission(SUBMISSION_JSON)
+        self.form_submission = PackageScanFormSubmission(VOUCHER_JSON)
 
     def test_voucher_qr_codes(self):
         self.assertEqual(['test'], self.form_submission.get_qr_codes())
 
     def test_package_qr_codes(self):
-        self.form_submission = PackageScanFormSubmission(NEW_PACKAGE_JSON)
-        self.assertEqual(set(['test']), self.form_submission.get_qr_codes())
-
-    def test_old_package_qr_codes(self):
-        self.form_submission = PackageScanFormSubmission(OLD_PACKAGE_JSON)
+        self.form_submission = PackageScanFormSubmission(PACKAGE_JSON)
         self.assertEqual(set(['test']), self.form_submission.get_qr_codes())
 
     def test_gps(self):
-        self.assertEqual(SUBMISSION_JSON['gps'], self.form_submission.gps)
+        self.assertEqual(VOUCHER_JSON['gps'], self.form_submission.gps)
 
     def test_no_gps(self):
-        data = SUBMISSION_JSON.copy()
+        data = VOUCHER_JSON.copy()
         data.pop('gps')
         self.form_submission = PackageScanFormSubmission(data)
         self.assertFalse(hasattr(self.form_submission, 'gps'))
 
     def test_submission_time(self):
         self.assertEqual(
-            SUBMISSION_JSON['_submission_time'],
+            VOUCHER_JSON['_submission_time'],
             self.form_submission._submission_time.strftime(SUBMITTED_AT_FORMAT))
 
     def test_get_latitude(self):
-        value = float(SUBMISSION_JSON['gps'].split(' ')[0])
+        value = float(VOUCHER_JSON['gps'].split(' ')[0])
         self.assertEqual(value, self.form_submission.get_lat())
 
     def test_get_latitude_no_gps(self):
-        data = SUBMISSION_JSON.copy()
+        data = VOUCHER_JSON.copy()
         data.pop('gps')
         self.form_submission = PackageScanFormSubmission(data)
         self.assertIsNone(self.form_submission.get_lat())
 
     def test_get_longitude(self):
-        value = float(SUBMISSION_JSON['gps'].split(' ')[1])
+        value = float(VOUCHER_JSON['gps'].split(' ')[1])
         self.assertEqual(value, self.form_submission.get_lng())
 
     def test_get_altitude(self):
-        value = float(SUBMISSION_JSON['gps'].split(' ')[2])
+        value = float(VOUCHER_JSON['gps'].split(' ')[2])
         self.assertEqual(value, self.form_submission.get_altitude())
 
     def test_get_accuracy(self):
-        value = float(SUBMISSION_JSON['gps'].split(' ')[3])
+        value = float(VOUCHER_JSON['gps'].split(' ')[3])
         self.assertEqual(value, self.form_submission.get_accuracy())
 
     def test_get_gps_data_out_of_range(self):

--- a/ona/tests/test_tasks.py
+++ b/ona/tests/test_tasks.py
@@ -13,7 +13,7 @@ from ona.representation import OnaItemBase
 from shipments.models import PackageScan, Shipment
 from shipments.tests.factories import PackageFactory
 from ona.models import FormSubmission, minimum_aware_datetime
-from ona.tasks import process_new_package_scans, verify_deviceid, reset_bad_form_ids, bad_form_ids, \
+from ona.tasks import process_new_scans, verify_deviceid, reset_bad_form_ids, bad_form_ids, \
     forget_form_definitions
 from ona.tests.test_models import PACKAGE_DATA, USER_CODE_DATA, QR_CODE
 
@@ -21,7 +21,7 @@ from ona.tests.test_models import PACKAGE_DATA, USER_CODE_DATA, QR_CODE
 @override_settings(
     ONA_API_ACCESS_TOKEN='foo',
     ONA_DEVICEID_VERIFICATION_FORM_ID=111,
-    ONA_PACKAGE_FORM_IDS=[123, 456],
+    ONA_FORM_IDS=[123, 456],
     ONA_DOMAIN='ona.io'
 )
 @patch('ona.tasks.OnaApiClient.get_form_submissions')
@@ -37,10 +37,10 @@ class ProcessNewPackageScansTestCase(TestCase):
         submission = json.loads(PACKAGE_DATA)
         mock_ona_form_def.return_value = submission['form_definition']
         mock_ona_form_submissions.return_value = [submission]
-        process_new_package_scans.run()
+        process_new_scans.run()
         self.assertEqual(1, FormSubmission.objects.count())
         # Only add the record once
-        process_new_package_scans.run()
+        process_new_scans.run()
         self.assertEqual(1, FormSubmission.objects.count())
 
     def test_update_package_multiple_locations(self, mock_ona_form_def, mock_ona_form_submissions):
@@ -56,7 +56,7 @@ class ProcessNewPackageScansTestCase(TestCase):
         )
         mock_ona_form_def.return_value = submission['form_definition']
         mock_ona_form_submissions.return_value = [submission, other_submission]
-        process_new_package_scans.run()
+        process_new_scans.run()
         self.assertEqual(2, FormSubmission.objects.count())
         loc = PackageScan.objects.all().order_by('when')[0]
         self.assertEqual(loc.status_label, 'English Zero_Point')
@@ -70,15 +70,23 @@ class ProcessNewPackageScansTestCase(TestCase):
     @patch('ona.tasks.logger')
     def test_bad_form_id(self, mock_logger, mock_ona_form_def, mock_ona_form_submissions):
         mock_ona_form_def.return_value = None
-        process_new_package_scans.run()
-        self.assertIn(123, bad_form_ids)
+        process_new_scans.run()
+        self.assertIn(settings.ONA_FORM_IDS[0], bad_form_ids)
         self.assertTrue(mock_logger.error.called)
+
+    @patch('ona.tasks.logger')
+    def test_skip_next_bad_form_id(self, mock_logger, mock_ona_form_def, mock_ona_form_submissions):
+        mock_ona_form_def.return_value = None
+        bad_form_ids.add(settings.ONA_FORM_IDS[0])
+        process_new_scans.run()
+        # no error logged because we just skip the bad form id
+        self.assertFalse(mock_logger.error.called)
 
 
 @override_settings(
     ONA_API_ACCESS_TOKEN='foo',
     ONA_DEVICEID_VERIFICATION_FORM_ID=111,
-    ONA_PACKAGE_FORM_IDS=[123, 456],
+    ONA_FORM_IDS=[123, 456],
     ONA_DOMAIN='ona.io'
 )
 @patch('ona.tasks.OnaApiClient.get_form_definition', autospec=True)

--- a/shipments/tests/test_views.py
+++ b/shipments/tests/test_views.py
@@ -803,7 +803,7 @@ class BulkEditPackageItemsViewTest(BaseViewTestCase):
         self.assertNoPermission(rsp)
 
 
-@override_settings(ONA_PACKAGE_FORM_IDS=[123, 456], ONA_DEVICEID_VERIFICATION_FORM_ID=111)
+@override_settings(ONA_FORM_IDS=[123, 456], ONA_DEVICEID_VERIFICATION_FORM_ID=111)
 class ShipmentDashboardViewTest(BaseViewTestCase):
     def setUp(self):
         super(ShipmentDashboardViewTest, self).setUp()
@@ -848,7 +848,7 @@ class ShipmentDashboardViewTest(BaseViewTestCase):
         self.assertNotIn(self.shipment, shipments)
 
 
-@override_settings(ONA_PACKAGE_FORM_IDS=[123, 456], ONA_DEVICEID_VERIFICATION_FORM_ID=111)
+@override_settings(ONA_FORM_IDS=[123, 456], ONA_DEVICEID_VERIFICATION_FORM_ID=111)
 class ShipmentPackageMapViewTest(BaseViewTestCase):
     def setUp(self):
         super(ShipmentPackageMapViewTest, self).setUp()


### PR DESCRIPTION
- Rename ONA_PACKAGE_FORM_IDS to ONA_FORM_IDS with the expectation that they may be either package forms or voucher forms
- Keep using `is_voucher()` do differentiate between the two
- Revert previous changes now that there will be only 1 type of Package Form, rather than 2 (old/new)
- Rename process_new_package_scans to be more accurate
