### PR TITLE
Set task expiration

### DIFF
--- a/cts/settings/base.py
+++ b/cts/settings/base.py
@@ -281,12 +281,16 @@ CELERYBEAT_SCHEDULE = {
     'process_new_scans': {
         'task': 'ona.tasks.process_new_scans',
         'schedule': timedelta(minutes=15),
-        'expires': 10*60,  # 10 minutes
+        'options': {
+            'expires': 10*60,  # 10 minutes
+        }
     },
     'verify_deviceid': {
         'task': 'ona.tasks.verify_deviceid',
         'schedule': timedelta(minutes=60),
-        'expires': 50*50,  # 50 minutes
+        'options': {
+            'expires': 50*50,  # 50 minutes
+        }
     },
 }
 CELERY_RESULT_BACKEND = None  # We never care about task results

--- a/cts/settings/base.py
+++ b/cts/settings/base.py
@@ -274,15 +274,19 @@ WORLD_BORDERS_SHAPEFILE = os.path.join(
     PROJECT_ROOT, 'shipments', 'data', 'TM_WORLD_BORDERS_SIMPL-0.3.shp'
 )
 
-
+# We set `expires` so that if the queue gets hung or the workers go down,
+# tasks don't pile up in the queue leading to a thundering herd problem
+# when things start running again.
 CELERYBEAT_SCHEDULE = {
     'process_new_scans': {
         'task': 'ona.tasks.process_new_scans',
         'schedule': timedelta(minutes=15),
+        'expires': 10*60,  # 10 minutes
     },
     'verify_deviceid': {
         'task': 'ona.tasks.verify_deviceid',
         'schedule': timedelta(minutes=60),
+        'expires': 50*50,  # 50 minutes
     },
 }
 CELERY_RESULT_BACKEND = None  # We never care about task results


### PR DESCRIPTION
Set an expiration time on scheduled tasks so that if
the worker goes down or something and the tasks pile
up in the queue, we won't try to run them all when
things start running again. Workers who are sent
expired tasks will fail them with a REVOKED status rather
than running them.
