### PR TITLE
Give each instance its own celery queue

### DIFF
--- a/cts/settings/base.py
+++ b/cts/settings/base.py
@@ -287,7 +287,7 @@ CELERYBEAT_SCHEDULE = {
 }
 CELERY_RESULT_BACKEND = None  # We never care about task results
 # Each instance needs its own queue
-CELERY_DEFAULT_QUEUE = 'queue_%s' % os.environ['INSTANCE']
+CELERY_DEFAULT_QUEUE = 'queue_%s' % INSTANCE
 
 # See https://github.com/johnsensible/django-sendfile
 SENDFILE_URL = "/protected/"

--- a/cts/settings/base.py
+++ b/cts/settings/base.py
@@ -286,6 +286,8 @@ CELERYBEAT_SCHEDULE = {
     },
 }
 CELERY_RESULT_BACKEND = None  # We never care about task results
+# Each instance needs its own queue
+CELERY_DEFAULT_QUEUE = 'queue_%s' % os.environ['INSTANCE']
 
 # See https://github.com/johnsensible/django-sendfile
 SENDFILE_URL = "/protected/"


### PR DESCRIPTION
This requires a corresponding change in CTS-ircdeploy
to point each worker at its own queue.
