### PR TITLE
Point upgrade for DRF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
   - "2.7"
 addons:
-  postgresql: "9.1"
+  postgresql: "9.2"
 env:
   - DJANGO_SETTINGS_MODULE="cts.settings.dev"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ sudo: false
 python:
   - "2.7"
 addons:
-  postgresql: "9.2"
+  postgresql: "9.5"
+  apt:
+    packages:
+    - postgresql-9.5-postgis-2.3
 env:
   - DJANGO_SETTINGS_MODULE="cts.settings.dev"
 install:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-appconf==1.0.1
 six==1.10.0
 xlrd==0.9.3
 django-session-security==2.2.0
-djangorestframework==2.4.2
+djangorestframework==2.4.3
   # optional reqs for django rest framework
   markdown==2.4
   defusedxml==0.4.1


### PR DESCRIPTION
The version of django-rest-framework that we are using is missing a migration file, which is included in the 2.4.3 version: https://github.com/encode/django-rest-framework/pull/1883

It's one of those issues where Django complains about a missing migration, but the actual migration doesn't alter data or schema, so I believe this is safe to apply to the running servers. (It won't actually apply anything, it will just quiet Django's complaint)

Tested locally.